### PR TITLE
AP-1849 Setting EcsFargate deployment model

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,7 +22,8 @@ output "agent_proxy_container" {
         environment = [
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "http://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:80"},
             {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs },
-            {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id }
+            {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
+            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs-fargate" }
         ]
     })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,8 @@ output "agent_proxy_container" {
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "http://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:80"},
             {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs },
             {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
-            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs-fargate" }
+            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
+
         ]
     })
 }


### PR DESCRIPTION
Situation

We set the deployment model env variable for VM and Lambda

Target

We want to set this env variable correctly for all deployment models.

Proposal

Set it automatically for all Agent Proxy deployed in ECS Fargate

Verification

Deployed to ECSFargate and checked in the logs that deployment model is shown correctly