### PR TITLE
Add TLS support for ECS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,13 +74,13 @@ resource "aws_ecs_task_definition" "agent-controller" {
 
 locals {
   # Extract the "base domain" (e.g. aembit-eng.com ) from the stack domain.
-  domain_parts = split(".", "${var.aembit_stack}")
-  base_domain = join(".", slice("${local.domain_parts}", 1, 3))
+  _domain_parts = split(".", "${var.aembit_stack}")
+  base_domain = join(".", slice("${local._domain_parts}", 1, 3))
 
   # Concatenating passed-in trusted CA certs with the tenant root CA
-  passed_in_certs_pem = !(var.aembit_trusted_ca_certs == null || var.aembit_trusted_ca_certs == "") ? base64decode("${var.aembit_trusted_ca_certs}") : null
-  all_trusted_ca_certs_pem = local.passed_in_certs_pem != null ? "${local.passed_in_certs_pem}\n${data.http.trusted_ca_cert.response_body}" : "${data.http.trusted_ca_cert.response_body}"
-  all_trusted_ca_certs_base64 = base64encode("${local.all_trusted_ca_certs_pem}")
+  _passed_in_certs_pem = !(var.aembit_trusted_ca_certs == null || var.aembit_trusted_ca_certs == "") ? base64decode("${var.aembit_trusted_ca_certs}") : null
+  _all_trusted_ca_certs_pem = local._passed_in_certs_pem != null ? "${local._passed_in_certs_pem}\n${data.http.trusted_ca_cert.response_body}" : "${data.http.trusted_ca_cert.response_body}"
+  all_trusted_ca_certs_base64 = base64encode("${local._all_trusted_ca_certs_pem}")
 }
 
 data "http" "trusted_ca_cert" {

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,8 @@ resource "aws_ecs_task_definition" "agent-controller" {
     environment = [
       {"name": "AEMBIT_TENANT_ID", "value": var.aembit_tenantid },
       {"name": "AEMBIT_STACK_DOMAIN", "value": var.aembit_stack },
-      {"name": "AEMBIT_AGENT_CONTROLLER_ID", "value": var.aembit_agent_controller_id }
+      {"name": "AEMBIT_AGENT_CONTROLLER_ID", "value": var.aembit_agent_controller_id },
+      {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"}
     ]
     healthCheck = {
       retries = 3

--- a/main.tf
+++ b/main.tf
@@ -78,9 +78,9 @@ locals {
   base_domain = join(".", slice("${local.domain_parts}", 1, 3))
 
   # Concatenating passed-in trusted CA certs with the tenant root CA
-  base64_decoded_env_certs = !(var.aembit_trusted_ca_certs == null || var.aembit_trusted_ca_certs == "") ? base64decode("${var.aembit_trusted_ca_certs}") : null
-  all_certs = local.base64_decoded_env_certs != null ? "${local.base64_decoded_env_certs}\n${data.http.trusted_ca_cert.response_body}" : "${data.http.trusted_ca_cert.response_body}"
-  all_certs_base64 = base64encode("${local.all_certs}")
+  passed_in_certs_pem = !(var.aembit_trusted_ca_certs == null || var.aembit_trusted_ca_certs == "") ? base64decode("${var.aembit_trusted_ca_certs}") : null
+  all_trusted_ca_certs_pem = local.passed_in_certs_pem != null ? "${local.passed_in_certs_pem}\n${data.http.trusted_ca_cert.response_body}" : "${data.http.trusted_ca_cert.response_body}"
+  all_trusted_ca_certs_base64 = base64encode("${local.all_trusted_ca_certs_pem}")
 }
 
 data "http" "trusted_ca_cert" {

--- a/main.tf
+++ b/main.tf
@@ -33,11 +33,10 @@ resource "aws_ecs_task_definition" "agent-controller" {
     image = var.agent_controller_image
     essential = true
     portMappings = [{
-      name          = "aembit_agent_controller_http"
-      containerPort = 80
-      hostPort      = 80
+      name          = "aembit_agent_controller_https"
+      containerPort = 443
+      hostPort      = 443
       protocol      = "tcp"
-      appProtocol   = "http"
     }]
     logConfiguration = (var.log_group_name != null ? {
       logDriver = "awslogs"

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,7 @@ output "agent_proxy_container" {
         } : null)
         environment = [
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
-            {"name": "TRUSTED_CA_CERTS", "value": data.http.trusted_ca_cert.response_body_base64 },
+            {"name": "TRUSTED_CA_CERTS", "value": local.all_certs_base64 },
             {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
             {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
         ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,9 +21,9 @@ output "agent_proxy_container" {
         } : null)
         environment = [
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
-            {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs},
-            {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id},
-            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate"}
+            {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs },
+            {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
+            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
         ]
     })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,6 @@ output "agent_proxy_container" {
             {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs},
             {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id},
             {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate"},
-            {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"}
         ]
     })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,11 +20,11 @@ output "agent_proxy_container" {
             }
         } : null)
         environment = [
-            {"name": "AEMBIT_AGENT_CONTROLLER", "value": "http://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:80"},
-            {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs },
-            {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
-            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
-
+            {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
+            {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs},
+            {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id},
+            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate"},
+            {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"}
         ]
     })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "agent_proxy_container" {
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
             {"name": "TRUSTED_CA_CERTS", "value": local.all_trusted_ca_certs_base64 },
             {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
-            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
+            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs-fargate" }
         ]
     })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,7 @@ output "agent_proxy_container" {
         } : null)
         environment = [
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
-            {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs },
+            {"name": "TRUSTED_CA_CERTS", "value": data.http.trusted_ca_cert.response_body_base64 },
             {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
             {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
         ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,7 @@ output "agent_proxy_container" {
         } : null)
         environment = [
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
-            {"name": "TRUSTED_CA_CERTS", "value": local.all_certs_base64 },
+            {"name": "TRUSTED_CA_CERTS", "value": local.all_trusted_ca_certs_base64 },
             {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
             {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
         ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "agent_proxy_container" {
             {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
             {"name": "TRUSTED_CA_CERTS", "value": var.aembit_trusted_ca_certs},
             {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id},
-            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate"},
+            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate"}
         ]
     })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "aembit_agent_controller_id" {
 
 variable "aembit_trusted_ca_certs" {
   type = string
-  description = "Additional CA Certificates that the Agent Proxy should trust for Server Workload connectivity."
+  description = "Additional CA Certificates that the Agent Proxy should trust for Server Workload connectivity, base64 encoded."
   default = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ variable "agent_controller_image" {
 variable "agent_proxy_image" {
   type = string
   description = "The container image to use for the Agent Proxy installation."
-  default = "aembit/aembit_agent_proxy:1.15.2093"
+  default = "aembit/aembit_agent_proxy:1.14.1980"
 }
 
 variable "agent_proxy_resource_set_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ variable "agent_controller_image" {
 variable "agent_proxy_image" {
   type = string
   description = "The container image to use for the Agent Proxy installation."
-  default = "aembit/aembit_agent_proxy:1.14.1980"
+  default = "aembit/aembit_agent_proxy:1.15.2093"
 }
 
 variable "agent_proxy_resource_set_id" {


### PR DESCRIPTION
# Situation
We currently don't support TLS for ECS. We're working on implementing TLS support for it in the AP, AC, and Aembit Cloud.

# Target
Enable this feature to be toggled, once the changes to the AP, AC, and Aembit Cloud are complete.

# Proposal
1. Automatically set the host name for the Aembit-managed TLS.
2. Update the Agent Controller information to use the HTTPS endpoint.

I went in favor of replacing the non-TLS endpoint with the TLS endpoint. Since we are able to handle the TLS configuration ourselves without any additional customer intervention, it makes sense to use TLS. 

We may want to consider making this optional if:
1. A customer requests this feature.
2. As a fallback, in the event we have issues with our cloud/CA.