### PR TITLE
EDGE-2529 Allow to configure additional env variables on Agent proxy for Terraform deployment

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,7 +32,7 @@ output "agent_proxy_container" {
     })
 }
 
-output "agent_proxy_default_env_variables" {
+output "agent_proxy_default_environment" {
     value = local.agent_proxy_default_environment_variables
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,12 @@
+locals {
+  agent_proxy_default_environment_variables = [
+        {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
+        {"name": "TRUSTED_CA_CERTS", "value": local.all_trusted_ca_certs_base64 },
+        {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
+        {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
+  ]
+}
+
 # Output for Agent Proxy sidecar container that must be added to Client Workload Task Definition
 output "agent_proxy_container" {
     value = jsonencode({
@@ -19,13 +28,12 @@ output "agent_proxy_container" {
                 awslogs-stream-prefix = "agent-proxy"
             }
         } : null)
-        environment = [
-            {"name": "AEMBIT_AGENT_CONTROLLER", "value": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443"},
-            {"name": "TRUSTED_CA_CERTS", "value": local.all_trusted_ca_certs_base64 },
-            {"name": "AEMBIT_RESOURCE_SET_ID", "value": var.agent_proxy_resource_set_id },
-            {"name": "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value": "ecs_fargate" }
-        ]
+        environment = local.agent_proxy_default_environment_variables
     })
+}
+
+output "agent_proxy_default_env_variables" {
+    value = local.agent_proxy_default_environment_variables
 }
 
 output "aembit_http_proxy" {


### PR DESCRIPTION
**Situation**

I realized that there is no way to configure different log levels for Agent Proxy for ECS.

Target

We want to be able to configure that. However, ultimately, we want to configure other env variables for Agent proxy, too

Proposal.

We had several approaches. The easiest one (install time) was to make the modifications included.

And it allows for a customer to use this code to specify additional env variables

```
    merge(jsondecode(module.aembit-ecs.agent_proxy_container), {
        environment = concat(module.aembit-ecs.agent_proxy_default_env_variables, [
          {"name": "AEMBIT_LOG_LEVEL", "value": "debug" }
        ]
    )}),
```

Just for comparison. This was the code that was used before and still could be used (if no additional env variables are needed).

```
jsondecode(module.aembit-ecs.agent_proxy_container),
```

