### PR TITLE
EDGEX-85 ECS: Agent Controller 1.20.1810: health status is unhealthy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,11 +53,11 @@ resource "aws_ecs_task_definition" "agent-controller" {
       {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"}
     ]
     healthCheck = {
-      retries = 3
+      retries = 6
       command = [ "CMD-SHELL", "/app/healthCheck" ]
-      timeout = 2
-      interval = 5
-      startPeriod = 5
+      timeout = 3
+      interval = 7
+      startPeriod = 30
     }
   }])
   task_role_arn = (var.agent_controller_task_role_arn == null ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ecsTaskExecutionRole" : var.agent_controller_task_role_arn)


### PR DESCRIPTION
### Situation
ECS was prematurely marking the Agent Controller task as `Unhealthy`, causing unnecessary task replacements during deployment. The default health check parameters were too aggressive, leading to failures before the service fully initialized.

### Target
Adjust ECS health check parameters to provide more tolerance during startup while maintaining service reliability. The goal is to prevent premature task replacements and ensure a stable deployment.

### Proposal
Update the ECS health check configuration to:
- `retries` → 6 (Allows more failed attempts before marking as `Unhealthy`)
- `timeout` → 3 (Ensures responses are properly accounted for)
- `interval` → 7 (Reduces check frequency for a more patient approach)
- `startPeriod` → 30 (Provides sufficient time for Agent Controller initialization)

### Testing
- Validated with multiple configurations.
- Successfully passed health checks without triggering unnecessary task replacements.
- Confirmed that ECS no longer marks tasks as `Unhealthy` before Agent Controller is fully initialized.