### PR TITLE
EDGEX-81 Allow HTTP to be disabled on Agent Controller to allow for collocation with other software that uses similar protocols on similar ports

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,8 @@ resource "aws_ecs_task_definition" "agent-controller" {
       {"name": "AEMBIT_STACK_DOMAIN", "value": var.aembit_stack },
       {"name": "AEMBIT_AGENT_CONTROLLER_ID", "value": var.aembit_agent_controller_id },
       {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"},
-      {"name": "AEMBIT_HTTP_PORT_DISABLED", "value": var.aembit_http_port_disabled ? "true" : "false" }
+      {"name": "AEMBIT_HTTP_PORT_DISABLED", "value": tostring(var.aembit_http_port_disabled) }
+
     ]
     healthCheck = {
       retries = 6

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,8 @@ resource "aws_ecs_task_definition" "agent-controller" {
       {"name": "AEMBIT_TENANT_ID", "value": var.aembit_tenantid },
       {"name": "AEMBIT_STACK_DOMAIN", "value": var.aembit_stack },
       {"name": "AEMBIT_AGENT_CONTROLLER_ID", "value": var.aembit_agent_controller_id },
-      {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"}
+      {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"},
+      {"name": "AEMBIT_HTTP_PORT_DISABLED", "value": var.aembit_http_port_disabled ? "true" : "false" }
     ]
     healthCheck = {
       retries = 6

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "aembit_stack" {
   default     = "useast2.aembit.io"
 }
 
+variable "aembit_http_port_disabled" {
+  type        = bool
+  description = "If true, the Agent Controller will not listen on its HTTP port (only HTTPS)."
+  default = false
+}
+
 variable "agent_controller_image" {
   type        = string
   description = "The container image to use for the Agent Controller installation."


### PR DESCRIPTION
### Situation
The Agent Controller enables HTTP by default, but some deployments require disabling HTTP to avoid conflicts with other services using port 80. The `AEMBIT_HTTP_PORT_DISABLED` variable has been implemented in the Agent Controller and Kubernetes Helm Chart. This PR introduces it into the ECS module.

### Target
- Allow ECS deployments to disable HTTP via `AEMBIT_HTTP_PORT_DISABLED`.
- Ensure consistency with Kubernetes Helm Chart and Agent Controller behavior.
- Pass the variable to the ECS task definition while maintaining a default value of "false".

### Proposal
- Add `aembit_http_port_disabled` as a Terraform variable.
- Pass it as an environment variable in the ECS task definition.
- Default to "false" to keep existing behavior unchanged.
- Ensure proper security group configurations if HTTP is disabled.

### Testing
TBD