### PR TITLE
Allow specifying ad-hoc Agent Proxy environment variables.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 locals {
   agent_proxy_default_environment_variables = {
-		"AEMBIT_AGENT_CONTROLLER": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443",
-		"TRUSTED_CA_CERTS": local.all_trusted_ca_certs_base64,
-		"AEMBIT_RESOURCE_SET_ID": var.agent_proxy_resource_set_id,
-		"AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL": "ecs_fargate",
-	}
+    "AEMBIT_AGENT_CONTROLLER" : "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443",
+    "TRUSTED_CA_CERTS" : local.all_trusted_ca_certs_base64,
+    "AEMBIT_RESOURCE_SET_ID" : var.agent_proxy_resource_set_id,
+    "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL" : "ecs_fargate",
+  }
   agent_proxy_effective_environment_variables = merge(local.agent_proxy_default_environment_variables, var.agent_proxy_environment_variables)
 }
 
@@ -30,8 +30,8 @@ output "agent_proxy_container" {
       }
     } : null)
     environment = [
-			for varname, varvalue in local.agent_proxy_effective_environment_variables : { "name": varname, "value": varvalue }
-		]
+      for varname, varvalue in local.agent_proxy_effective_environment_variables : { "name" : varname, "value" : varvalue }
+    ]
   })
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,11 @@
 locals {
-  agent_proxy_default_environment_variables = [
-    { "name" : "AEMBIT_AGENT_CONTROLLER", "value" : "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443" },
-    { "name" : "TRUSTED_CA_CERTS", "value" : local.all_trusted_ca_certs_base64 },
-    { "name" : "AEMBIT_RESOURCE_SET_ID", "value" : var.agent_proxy_resource_set_id },
-    { "name" : "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL", "value" : "ecs_fargate" }
-  ]
+  agent_proxy_default_environment_variables = {
+		"AEMBIT_AGENT_CONTROLLER": "https://${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}:443",
+		"TRUSTED_CA_CERTS": local.all_trusted_ca_certs_base64,
+		"AEMBIT_RESOURCE_SET_ID": var.agent_proxy_resource_set_id,
+		"AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL": "ecs_fargate",
+	}
+  agent_proxy_effective_environment_variables = merge(local.agent_proxy_default_environment_variables, var.agent_proxy_environment_variables)
 }
 
 # Output for Agent Proxy sidecar container that must be added to Client Workload Task Definition
@@ -28,7 +29,9 @@ output "agent_proxy_container" {
         awslogs-stream-prefix = "agent-proxy"
       }
     } : null)
-    environment = local.agent_proxy_default_environment_variables
+    environment = [
+			for varname, varvalue in local.agent_proxy_effective_environment_variables : { "name": varname, "value": varvalue }
+		]
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "agent_proxy_resource_set_id" {
   default     = null
 }
 
+variable "agent_proxy_environment_variables" {
+  type        = map(string)
+  description = "A map of environment variables to define in the Agent Proxy container."
+  default     = {}
+}
+
 # ECS CLUSTER Specific Variables
 variable "ecs_cluster" {
   type        = string


### PR DESCRIPTION
Our helm chart allows the customer to specify ad-hoc environment variables to be specified for the injected Agent Proxy container. This PR aims to provide similar ad-hoc environment variable functionality for the Agent Proxy ECS container definition.

In my test deployment I specified:
```tf
module "ecs" {
	source = "git::ssh://git@github.com/Aembit/terraform-aembit-ecs?ref=feature/ap-env-vars"
	# ...
	agent_proxy_environment_variables = {
		"AEMBIT_PASS_THROUGH_TRAFFIC_BEFORE_REGISTRATION": "false"
	}
}

output "proxy_container_def" {
	value = jsondecode(module.ecs.agent_proxy_container)
}
```

And after applying the changes, the output shows:

```tf
agent_proxy_container_definition = {
  "environment" = [
    {
      "name" = "AEMBIT_AGENT_CONTROLLER"
      "value" = "https://agent-controller.aembit.local:443"
    },
    {
      "name" = "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL"
      "value" = "ecs_fargate"
    },
    {
      "name" = "AEMBIT_PASS_THROUGH_TRAFFIC_BEFORE_REGISTRATION"
      "value" = "false"
    },
    {
      "name" = "AEMBIT_RESOURCE_SET_ID"
      "value" = null
    },
    # ...
```

I've also used this to deploy a Globex service on Fargate and confirmed that the environment variable is properly injected into the AP container within the task and that the previous default environment variables still remain:

<img width="962" alt="Screenshot 2025-04-17 at 2 53 58 PM" src="https://github.com/user-attachments/assets/cbabcd29-b5d1-4ebd-a684-aa60530d945a" />
