### PR TITLE
EDGEX-2138 ECS Terraform Modue: Add the ability to change the logging level of the Agent Controller to the Terraform module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,8 @@ resource "aws_ecs_task_definition" "agent-controller" {
       {"name": "AEMBIT_STACK_DOMAIN", "value": var.aembit_stack },
       {"name": "AEMBIT_AGENT_CONTROLLER_ID", "value": var.aembit_agent_controller_id },
       {"name": "AEMBIT_MANAGED_TLS_HOSTNAME", "value": "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}"},
-      {"name": "AEMBIT_HTTP_PORT_DISABLED", "value": tostring(var.aembit_http_port_disabled) }
+      {"name": "AEMBIT_HTTP_PORT_DISABLED", "value": tostring(var.aembit_http_port_disabled) },
+      {"name": "AEMBIT_LOG_LEVEL", "value": var.agent_controller_log_level }
 
     ]
     healthCheck = {

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,16 @@ variable "aembit_http_port_disabled" {
   default = false
 }
 
+variable "agent_controller_log_level" {
+  type        = string
+  description = "Log level for the Agent Controller. Must be one of: fatal, error, warning, information, debug, verbose."
+  default     = "information"
+  validation {
+    condition     = contains(["fatal", "error", "warning", "information", "debug", "verbose"], var.agent_controller_log_level)
+    error_message = "agent_controller_log_level must be one of: fatal, error, warning, information, debug, verbose."
+  }
+}
+
 variable "agent_controller_image" {
   type        = string
   description = "The container image to use for the Agent Controller installation."


### PR DESCRIPTION
### Situation
Currently, the ECS Terraform module for Agent Controller does not allow users to configure the logging level. This limits observability and makes debugging harder during development and QA tests.

### Target
Allow users to configure the `AEMBIT_LOG_LEVEL` environment variable for the Agent Controller via the Terraform module, using a validated list of allowed values.

### Proposal
- Introduced a new `agent_controller_log_level` variable in `variables.tf`, with a default value of "**information**".
- Used Terraform custom validation to restrict values to: fatal, error, warning, information, debug, verbose.
- Injected this value into the environment block of the ECS task definition as `AEMBIT_LOG_LEVEL`.

### Testing
TBD