### PR TITLE
EDGEX-2138 ECS Terraform Module: Add the ability to change the logging level of the Agent Controller to the Terraform module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,14 +46,20 @@ resource "aws_ecs_task_definition" "agent-controller" {
         awslogs-stream-prefix = "agent_controller"
       }
     } : null)
-    environment = [
-      { "name" : "AEMBIT_TENANT_ID", "value" : var.aembit_tenantid },
-      { "name" : "AEMBIT_STACK_DOMAIN", "value" : var.aembit_stack },
-      { "name" : "AEMBIT_AGENT_CONTROLLER_ID", "value" : var.aembit_agent_controller_id },
-      { "name" : "AEMBIT_MANAGED_TLS_HOSTNAME", "value" : "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}" },
-      { "name" : "AEMBIT_HTTP_PORT_DISABLED", "value" : tostring(var.aembit_http_port_disabled) },
-      { "name" : "AEMBIT_LOG_LEVEL", "value" : var.agent_controller_log_level }
-    ]
+    environment = concat(
+    [
+      { name = "AEMBIT_TENANT_ID", value = var.aembit_tenantid },
+      { name = "AEMBIT_STACK_DOMAIN", value = var.aembit_stack },
+      { name = "AEMBIT_AGENT_CONTROLLER_ID", value = var.aembit_agent_controller_id },
+      { name = "AEMBIT_MANAGED_TLS_HOSTNAME", value = "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}" },
+      { name = "AEMBIT_HTTP_PORT_DISABLED", value = tostring(var.aembit_http_port_disabled) }
+    ],
+    [
+      for name, value in var.agent_controller_environment_variables : {
+        name  = name
+        value = value
+      }
+    ])
     healthCheck = {
       retries     = 6
       command     = ["CMD-SHELL", "/app/healthCheck"]

--- a/main.tf
+++ b/main.tf
@@ -46,20 +46,12 @@ resource "aws_ecs_task_definition" "agent-controller" {
         awslogs-stream-prefix = "agent_controller"
       }
     } : null)
-    environment = concat(
-    [
-      { name = "AEMBIT_TENANT_ID", value = var.aembit_tenantid },
-      { name = "AEMBIT_STACK_DOMAIN", value = var.aembit_stack },
-      { name = "AEMBIT_AGENT_CONTROLLER_ID", value = var.aembit_agent_controller_id },
-      { name = "AEMBIT_MANAGED_TLS_HOSTNAME", value = "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}" },
-      { name = "AEMBIT_HTTP_PORT_DISABLED", value = tostring(var.aembit_http_port_disabled) }
-    ],
-    [
-      for name, value in var.agent_controller_environment_variables : {
+    environment = [
+      for name, value in local.agent_controller_effective_environment_variables : {
         name  = name
         value = value
       }
-    ])
+    ]
     healthCheck = {
       retries     = 6
       command     = ["CMD-SHELL", "/app/healthCheck"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,19 @@ locals {
     "AEMBIT_AGENT_PROXY_DEPLOYMENT_MODEL" : "ecs_fargate",
   }
   agent_proxy_effective_environment_variables = merge(local.agent_proxy_default_environment_variables, var.agent_proxy_environment_variables)
+
+  agent_controller_default_environment_variables = {
+    "AEMBIT_TENANT_ID"              = var.aembit_tenantid,
+    "AEMBIT_STACK_DOMAIN"           = var.aembit_stack,
+    "AEMBIT_AGENT_CONTROLLER_ID"    = var.aembit_agent_controller_id,
+    "AEMBIT_MANAGED_TLS_HOSTNAME"   = "${aws_service_discovery_service.agent-controller.name}.${aws_service_discovery_private_dns_namespace.agent-controller.name}",
+    "AEMBIT_HTTP_PORT_DISABLED"     = tostring(var.aembit_http_port_disabled)
+  }
+
+  agent_controller_effective_environment_variables = merge(
+    local.agent_controller_default_environment_variables,
+    var.agent_controller_environment_variables
+  )
 }
 
 # Output for Agent Proxy sidecar container that must be added to Client Workload Task Definition

--- a/variables.tf
+++ b/variables.tf
@@ -45,14 +45,10 @@ variable "aembit_http_port_disabled" {
   default     = false
 }
 
-variable "agent_controller_log_level" {
-  type        = string
-  description = "Log level for the Agent Controller. Must be one of: fatal, error, warning, information, debug, verbose."
-  default     = "warning"
-  validation {
-    condition     = contains(["fatal", "error", "warning", "information", "debug", "verbose"], var.agent_controller_log_level)
-    error_message = "agent_controller_log_level must be one of: fatal, error, warning, information, debug, verbose."
-  }
+variable "agent_controller_environment_variables" {
+  type        = map(string)
+  description = "Optional environment variables for the Agent Controller container, e.g. AEMBIT_LOG_LEVEL."
+  default     = {}
 }
 
 variable "agent_controller_image" {
@@ -76,6 +72,12 @@ variable "agent_proxy_resource_set_id" {
 variable "agent_proxy_environment_variables" {
   type        = map(string)
   description = "A map of environment variables to define in the Agent Proxy container."
+  default     = {}
+}
+
+variable "agent_controller_environment_variables" {
+  type        = map(string)
+  description = "A map of environment variables to define in the Agent Controller container."
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,12 +45,6 @@ variable "aembit_http_port_disabled" {
   default     = false
 }
 
-variable "agent_controller_environment_variables" {
-  type        = map(string)
-  description = "Optional environment variables for the Agent Controller container, e.g. AEMBIT_LOG_LEVEL."
-  default     = {}
-}
-
 variable "agent_controller_image" {
   type        = string
   description = "The container image to use for the Agent Controller installation."


### PR DESCRIPTION
### Situation
The ECS Terraform module previously used a dedicated variable (`agent_controller_log_level`) to set the `AEMBIT_LOG_LEVEL` environment variable for the Agent Controller. Meanwhile, the Agent Proxy already supports dynamic environment variable injection via a map.

### Target
Unify the configuration style between Agent Proxy and Agent Controller by allowing `AEMBIT_LOG_LEVEL` to be set dynamically using `agent_controller_environment_variables`.

### Proposal
- Removed the `agent_controller_log_level` variable entirely.
- Introduced `agent_controller_environment_variables` as a map input to support dynamic environment variables.
- Updated the ECS task definition to read environment variables from the provided map.

### Testing
The following configuration was added to `globex-ecs.tf` and deployed successfully:
```
agent_controller_environment_variables = {
  "AEMBIT_LOG_LEVEL" = "debug"
}
``` 
After deployment, debug-level logs were observed in CloudWatch, confirming the environment variable was correctly applied.