### PR TITLE
Contrain version to avoid false-negative error from terraform 1.13 when 0 tests exist.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.5, < 1.13.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Contrain version to avoid false-negative error from terraform 1.13 when 0 tests exist.