### PR TITLE
AC-72 Agent Controller startup crash due to port 80 binding permission error on ECS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,10 @@ resource "aws_ecs_task_definition" "agent-controller" {
     name      = "${var.ecs_task_prefix}agent_controller"
     image     = var.agent_controller_image
     essential = true
+    systemControls = [{
+      namespace = "net.ipv4.ip_unprivileged_port_start"
+      value     = "80"
+    }]
     portMappings = [{
       name          = "aembit_agent_controller_https"
       containerPort = 443


### PR DESCRIPTION
### Situation
Agent Controller runs as a non-root user on ECS Fargate. Binding to low-numbered ports can fail due to privileged port restrictions.

### Target
Keep running as **non-root** on ECS Fargate while allowing the service to listen on the required ports.

### Proposal
Update the Agent Controller task definition to set:

```
systemControls: net.ipv4.ip_unprivileged_port_start = 80
``` 

This makes ports 80 and above available to non-root processes at runtime.

### Testing
Deployed to ECS Fargate with this task definition change and confirmed the Agent Controller service starts normally and passes health checks.